### PR TITLE
Update sensor.py

### DIFF
--- a/my_components/energy_meter_mercury230/sensor.py
+++ b/my_components/energy_meter_mercury230/sensor.py
@@ -150,7 +150,7 @@ ratioSensor=sensor.sensor_schema(
     )
 
 initParams = {
-     cv.GenerateID(): cv.declare_id(Mercury230),
+     # cv.GenerateID(): cv.declare_id(Mercury230),
      # частота
      cv.Optional(CONF_FREQUENCY): sensor.sensor_schema(
         unit_of_measurement=UNIT_HERTZ,
@@ -226,7 +226,8 @@ initParams[cv.Optional(CONF_POWER_FACTOR+PhA)] = ratioSensor;
 initParams[cv.Optional(CONF_POWER_FACTOR+PhB)] = ratioSensor;
 initParams[cv.Optional(CONF_POWER_FACTOR+PhC)] = ratioSensor;
 
-CONFIG_SCHEMA = cv.All(sensor.SENSOR_SCHEMA.extend(initParams).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA), output_info)
+#CONFIG_SCHEMA = cv.All(sensor.SENSOR_SCHEMA.extend(initParams).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA), output_info)
+CONFIG_SCHEMA = cv.All(sensor.sensor_schema(Mercury230).extend(initParams).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA), output_info)
 
 async def to_code(config):
     #_LOGGER.info("--------------")
@@ -340,4 +341,5 @@ async def to_code(config):
     # update intrerval
     if (CONF_UPDATE_INTERVAL) in config:
         cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
+
 


### PR DESCRIPTION
использование SENSOR_SCHEMA запрещено с версии esphome 2025.11.0 нужно использовать sensor_schema. Поправил код и проверил его.